### PR TITLE
Don't insert spurious <body> nodes into the document

### DIFF
--- a/src/lib/Renderer.js
+++ b/src/lib/Renderer.js
@@ -14,7 +14,7 @@ class Renderer {
 
 	appendTemplateToDOM( template, el ) {
 		if ( el ) {
-			el.append( template.body );
+			el.append( ...template.body.childNodes );
 		}
 	}
 }


### PR DESCRIPTION
This patch assumes that the templates will consist of exactly one DOM element,
which is true for both existing cases (PherritLink and PherritLinkGroup).

Fixes #4.