### PR TITLE
Update for changes in `data-sigil` attribute in Phabricator HTML

### DIFF
--- a/src/lib/Page.js
+++ b/src/lib/Page.js
@@ -3,7 +3,7 @@
  */
 class Page {
 	get cards() {
-		return document.querySelectorAll( '[data-sigil=" project-card"]' );
+		return document.querySelectorAll( '[data-sigil~="project-card"]' );
 	}
 
 	get ticketNumbers() {


### PR DESCRIPTION
It looks like the attribute has changed from `data-sigil=" project-card"`
to `data-sigil=" project-card draggable-card"`. Update the selector to be
less strict (`~=` matches space-separated values in the attribute).